### PR TITLE
Bump matb33:collection-hooks to latest 0.7.11

### DIFF
--- a/package.js
+++ b/package.js
@@ -18,7 +18,7 @@ Package.onUse(function (api) {
     'mongo' // Mongo.Collection available
   ]);
 
-  api.use("matb33:collection-hooks@0.7.5");
+  api.use("matb33:collection-hooks@0.7.11");
 
   api.addFiles('common.coffee');
 


### PR DESCRIPTION
Fixes #6

Re-run tests, all pass.

I'd like to bump the version to pick up last few versions of bug fixes, and generally keep up to date.