### PR TITLE
Remove findHook shortcut on select by _id

### DIFF
--- a/grouping.coffee
+++ b/grouping.coffee
@@ -140,11 +140,6 @@ findHook = (userId, selector, options) ->
   # Don't scope for direct operations
   return true if Partitioner._directOps.get() is true
 
-  # for find(id) we should not touch this
-  # TODO this may allow arbitrary finds across groups with the right _id
-  # We could amend this in the future to {_id: someId, _groupId: groupId}
-  return true if _.isString(selector) or (selector? and "_id" of selector)
-
   # Check for global hook
   groupId = Partitioner._currentGroup.get()
   unless groupId
@@ -195,5 +190,3 @@ TestFuncs =
   userFindHook: userFindHook
   findHook: findHook
   insertHook: insertHook
-
-

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "mizzao:partitioner",
   summary: "Transparently divide a meteor app into different instances shared between groups of users.",
-  version: "0.5.4",
+  version: "0.5.5",
   git: "https://github.com/mizzao/meteor-partitioner.git"
 });
 


### PR DESCRIPTION
This (as commented) allowed finds across groups if the _id was known. I'm not sure on the use case for this, but in applications which rely on tenants being completely  unable to see each other this was a fairly large hole in securely partitioning them.