### PR TITLE
Replace upsert with update to prevent adding empty records.

### DIFF
--- a/grouping.coffee
+++ b/grouping.coffee
@@ -186,11 +186,11 @@ insertHook = (userId, doc) ->
 # Sync grouping needed for hooking Meteor.users
 Grouping.find().observeChanges
   added: (id, fields) ->
-    Meteor.users.upsert(id, $set: {"group": fields.groupId} )
+    Meteor.users.update(id, $set: {"group": fields.groupId} )
   changed: (id, fields) ->
-    Meteor.users.upsert(id, $set: {"group": fields.groupId} )
+    Meteor.users.update(id, $set: {"group": fields.groupId} )
   removed: (id) ->
-    Meteor.users.upsert(id, $unset: {"group": null} )
+    Meteor.users.update(id, $unset: {"group": null} )
 
 TestFuncs =
   getPartitionedIndex: getPartitionedIndex

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "mizzao:partitioner",
   summary: "Transparently divide a meteor app into different instances shared between groups of users.",
-  version: "0.5.7",
+  version: "0.5.8",
   git: "https://github.com/mizzao/meteor-partitioner.git"
 });
 


### PR DESCRIPTION
This fixes the issue with inserting empty data into the collections.

I have situation where i need to delete a user. This is the code i'm running on server to achieve that:
```javascript
    Partitioner.clearUserGroup(userId);
    Users.remove({_id: userId});
```

Partitioner properly removes entry from `ts.grouping` collection, but `removed` "hook" is triggered afterwards, probably several times, and inserts the user back to the table with the `_id` field only. I also tried doing something like this, but it didn't help:
```javascript
Grouping.remove(userId, function() {
  Users.remove({_id: userId });
});

// With collection hooks package
Grouping.after.remove(userId, function(userId, doc) {
  Users.remove({_id: doc._id });
});
```

This should fix the problem because update will only work if entry exists in the collection.